### PR TITLE
Multiple file pattern match

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,13 @@ export default function finf(path, pattern) {
   let files = [];
    
   if(pattern != undefined) {
-    pattern = fp(pattern);
-    for(let i=0;i<list.length;i++) {
-      let file = list[i];
-      if(pattern.test(file)) files.push(file); 
+    parts = pattern.split("|");
+    for(p in parts) {
+      pattern = fp(p);
+      for(let i=0;i<list.length;i++) {
+        let file = list[i];
+        if(pattern.test(file)) files.push(file); 
+      }
     }
   }else {
     files = list


### PR DESCRIPTION
Added the ability to match on multiple file patterns seperated by a pipe.

e.g.  "*.js|*.css|*.html" would return files that match any of the patterns.